### PR TITLE
Add configure procedure to hide units from log

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ attachLogger(myDomain, {
 });
 ```
 
+### Hide any unit from log
+
+Sometimes it is required to hide some events or stores from log.
+It is simple to implement: just call `configure` on your unit.
+
+```ts
+import { createEvent } from 'effector'
+import { configure } from 'effector-logger'
+import { $data, loadDataFx } from './model'
+
+const pageMounted = createEvent<number>();
+
+configure(pageMounted, { log: 'disabled' })
+
+// You can pass multiple units as array
+configure([$data, loadDataFx], { log: 'disabled' })
+```
+
 ## effector-root
 
 Just import `root` domain and attach:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as effector from 'effector';
-import { attachLogger } from './attach';
+import { attachLogger, configure } from './attach';
 import { LOGGER_DOMAIN_NAME } from './lib';
 
 const root = effector.createDomain(LOGGER_DOMAIN_NAME);
@@ -8,5 +8,5 @@ attachLogger(root);
 
 const { createDomain, createStore, createEffect, createEvent } = root;
 
-export { createDomain, createStore, createEffect, createEvent };
+export { createDomain, createStore, createEffect, createEvent, configure };
 export * from 'effector';


### PR DESCRIPTION

Sometimes it is required to hide some events or stores from log.
It is simple to implement: just call `configure` on your unit.

```ts
import { createEvent } from 'effector'
import { configure } from 'effector-logger'
import { $data, loadDataFx } from './model'

const pageMounted = createEvent<number>();

configure(pageMounted, { log: 'disabled' })

// You can pass multiple units as array
configure([$data, loadDataFx], { log: 'disabled' })
```
