### PR TITLE
Add possibility to enable/disable effector-logger for exact import

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ Add babel plugin to your `babel.config.js` or `.babelrc` file
 Babel plugin has few configuration options:
 - `inspector: boolean` - enables or disables `effector-inspector`. Default: `false`
 - `effector: EffectorBabelPluginOptions` - overrides for underlying `effector/babel-plugin`. Default: `{}`
+- `disabled: boolean` - disables plugin. Default `false`. If plugin is disabled, you can enable it for exact `effector` import by using comment `// effector-logger: enable` after import. And vice-versa:
+
+```js
+// effector-logger is enabled in config (by default)
+import { createStore } from 'effector' // effector-logger: disable
+
+// effector-logger is disabled in config
+import { createStore } from 'effector' // effector-logger: enable
+```
 
 Config example:
 ```json
@@ -160,7 +169,7 @@ attachLogger(root);
 
 ## Inspector
 
-Just import `effector-logger/inspector` in the `app.ts` and open DevTools Console in browser. 
+Just import `effector-logger/inspector` in the `app.ts` and open DevTools Console in browser.
 
 > Note: inspector requires browser environment. ReactNative is not supported
 

--- a/babel-plugin.js
+++ b/babel-plugin.js
@@ -5,12 +5,24 @@ module.exports = function effectorLogger(babel, options = {}) {
   const { inspector = false, effector = {}, skipEffectorPlugin = false } = options;
 
   const replaceToLogger = ['effector'];
+  const disableRe = /^\s*effector-logger:\s*disable\s*.*$/
+
+  const isLoggerDisabled = (node) => {
+    if (node.trailingComments) {
+      for (const comment of node.trailingComments) {
+        if (comment && disableRe.test(comment.value)) {
+          return true
+        }
+      }
+    }
+  }
 
   const importVisitor = {
     ImportDeclaration(path, state) {
       if (t.isLiteral(path.node.source)) {
         // If imported from module that should be replaced to logger as is
-        if (replaceToLogger.includes(path.node.source.value)) {
+        // and does not contain trailing comment `effector-logger: disable`
+        if (replaceToLogger.includes(path.node.source.value) && !isLoggerDisabled(path.node)) {
           path.node.source.value = 'effector-logger';
         }
       }


### PR DESCRIPTION
Add possibility to forbid for babel plugin to change exact `effector` import to `effector-logger`.

```js
import { createStore } from 'effector' // effector-logger: disable
```

Checks only trailing comments, so techically it is possible to have multiple effector imports, one disabled and other not:

```js
import { createStore } from 'effector' // effector-logger: disable
import { createEffect } from 'effector'
```

or even

```js
import { createStore } from 'effector' // effector-logger: disable
import { createStore as createStoreWithLogger } from 'effector'
```

though I don't know, how it will work :)